### PR TITLE
Upgrades the GitHub workflows to gradle-build-action v2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,6 +21,3 @@ jobs:
         with:
           gradle-version: 7.1.1
           arguments: publishPlugins
-      - name: Publish annotation
-        run: 'echo "::warning::Publish build scan: ${{ steps.publish.outputs.build-scan-url }}"'
-        if: ${{ always() }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,9 +29,6 @@ jobs:
           arguments: dockerPush
           build-root-directory: examples
           gradle-version: ${{ matrix.gradle-version }}
-      - name: Publish 'Docker CLI test' annotation
-        run: 'echo "::warning::Java ${{ matrix.java-version }}, Gradle ${{ matrix.gradle-version }} | Docker CLI test build scan: ${{ steps.docker-cli.outputs.build-scan-url }}"'
-        if: ${{ always() }}
 
       - name: Docker REST API test
         uses: gradle/gradle-build-action@v2
@@ -47,9 +44,6 @@ jobs:
           arguments: dockerPush
           build-root-directory: examples
           gradle-version: ${{ matrix.gradle-version }}
-      - name: Publish 'Docker REST API' annotation
-        run: 'echo "::warning::Java ${{ matrix.java-version }}, Gradle ${{ matrix.gradle-version }} | Docker REST API test build scan: ${{ steps.docker-rest.outputs.build-scan-url }}"'
-        if: matrix.os != 'windows-latest'
 
       # liquibase tests
       - name: Liquibase test
@@ -60,9 +54,6 @@ jobs:
           arguments: liquibaseUpdate
           build-root-directory: examples
           gradle-version: ${{ matrix.gradle-version }}
-      - name: Publish Liquibase annotation
-        run: 'echo "::warning::Java ${{ matrix.java-version }}, Gradle ${{ matrix.gradle-version }} | Liquibase test build scan: ${{ steps.liquibase.outputs.build-scan-url }}"'
-        if: ${{ always() }}
 
       # terraform tests
       - name: Terraform test
@@ -73,6 +64,3 @@ jobs:
           arguments: terraformInit
           build-root-directory: examples
           gradle-version: ${{ matrix.gradle-version }}
-      - name: Publish Terraform annotation
-        run: 'echo "::warning::Java ${{ matrix.java-version }}, Gradle ${{ matrix.gradle-version }} | Terraform test build scan: ${{ steps.terraform.outputs.build-scan-url }}"'
-        if: ${{ always() }}


### PR DESCRIPTION
Upgrades the GitHub actions workflows to the latest v2 version (presently v2.0-rc.1).
This new action:
- has simpler configuration
- does a better job of caching the Gradle User Home state between build invocations
- automatically adds annotations with build scan URLs for all gradle invocations.

Because of the last item, I also removed the generation of warning annotations containing build scan URLs. There's a minor regression here, since I have not yet found a way to clearly differentiate multiple gradle invocations in the same job.
